### PR TITLE
Allow name override

### DIFF
--- a/shinyproxy/Chart.yaml
+++ b/shinyproxy/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: shinyproxy
 description: A Helm chart to install Shinyproxy
 type: application
-version: 0.6.4
+version: 0.6.5
 appVersion: 2.6.1

--- a/shinyproxy/templates/_helpers.tpl
+++ b/shinyproxy/templates/_helpers.tpl
@@ -61,3 +61,11 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{- define "shinyproxy.resourcename" -}}
+{{- if .Values.useReleaseName }}
+{{- printf "%s" (include "shinyproxy.fullname" .) }}
+{{- else }}
+{{- printf "%s" "shinyproxy" }}
+{{- end }}
+{{- end }}

--- a/shinyproxy/templates/configmap.yaml
+++ b/shinyproxy/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: shinyproxy
+  name: {{ include "shinyproxy.resourcename" . }}
   labels:
     {{- include "shinyproxy.labels" . | nindent 4 }}
 data:

--- a/shinyproxy/templates/deployment.yaml
+++ b/shinyproxy/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   labels:
     {{- include "shinyproxy.labels" . | nindent 4 }}
-  name: shinyproxy
+  name: {{ include "shinyproxy.resourcename" . }}
 spec:
   replicas: 1
   selector:
@@ -31,7 +31,7 @@ spec:
             - name: SPRING_APPLICATION_JSON
               valueFrom:
                 secretKeyRef:
-                  name: shinyproxy
+                  name: {{ include "shinyproxy.resourcename" . }}
                   key: secrets.json 
           volumeMounts:
           - name: application-conf
@@ -63,8 +63,8 @@ spec:
             initialDelaySeconds: 40
             timeoutSeconds: 5
           {{- end }}
-      serviceAccountName: shinyproxy
+      serviceAccountName: {{ include "shinyproxy.resourcename" . }}
       volumes:
       - name: application-conf
         configMap:
-          name: shinyproxy
+          name: {{ include "shinyproxy.resourcename" . }}

--- a/shinyproxy/templates/hooks.yaml
+++ b/shinyproxy/templates/hooks.yaml
@@ -16,7 +16,7 @@ spec:
         {{- include "shinyproxy.labels" . | nindent 8 }}
     spec:
       restartPolicy: Never
-      serviceAccountName: shinyproxy
+      serviceAccountName: {{ include "shinyproxy.resourcename" . }}
       containers:
       - name: delete-user-pods
         image: bitnami/kubectl:{{ .Capabilities.KubeVersion.Major }}.{{ .Capabilities.KubeVersion.Minor }}

--- a/shinyproxy/templates/ingress.yaml
+++ b/shinyproxy/templates/ingress.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.ingress.enabled -}}
+{{- $name := include "shinyproxy.resourcename" . }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -20,7 +21,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ include "shinyproxy.resourcename" . }}
+                name: {{ $name }}
                 port: 
                   number: 8080
     {{- end }}

--- a/shinyproxy/templates/ingress.yaml
+++ b/shinyproxy/templates/ingress.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: shinyproxy
+  name: {{ include "shinyproxy.resourcename" . }}
   labels:
     {{- include "shinyproxy.labels" . | nindent 4 }}
   annotations:
@@ -20,7 +20,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: shinyproxy
+                name: {{ include "shinyproxy.resourcename" . }}
                 port: 
                   number: 8080
     {{- end }}

--- a/shinyproxy/templates/rbac.yaml
+++ b/shinyproxy/templates/rbac.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: shinyproxy
+  name: {{ include "shinyproxy.resourcename" . }}
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: shinyproxy
+  name: {{ include "shinyproxy.resourcename" . }}
   namespace: {{ default .Release.Namespace .Values.proxy.kubernetes.namespace }}
 rules:
   - apiGroups: [""]       # "" indicates the core API group
@@ -19,13 +19,13 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: shinyproxy
+  name: {{ include "shinyproxy.resourcename" . }}
   namespace: {{ default .Release.Namespace .Values.proxy.kubernetes.namespace }}
 subjects:
   - kind: ServiceAccount
-    name: shinyproxy
+    name: {{ include "shinyproxy.resourcename" . }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
   apiGroup: rbac.authorization.k8s.io
-  name: shinyproxy
+  name: {{ include "shinyproxy.resourcename" . }}

--- a/shinyproxy/templates/secrets.yaml
+++ b/shinyproxy/templates/secrets.yaml
@@ -1,7 +1,7 @@
 kind: Secret
 apiVersion: v1
 metadata:
-  name: shinyproxy
+  name: {{ include "shinyproxy.resourcename" . }}
   labels:
     {{- include "shinyproxy.labels" . | nindent 4 }}
 type: Opaque

--- a/shinyproxy/templates/service.yaml
+++ b/shinyproxy/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: shinyproxy
+  name: {{ include "shinyproxy.resourcename" . }}
   labels:
     {{- include "shinyproxy.labels" . | nindent 4 }}
   {{- if .Values.proxy.service.annotations }}

--- a/shinyproxy/values.yaml
+++ b/shinyproxy/values.yaml
@@ -65,3 +65,4 @@ proxy:
       cpu: 300m
       memory: 800Mi
 createUsersNamespace: false
+useReleaseName: false


### PR DESCRIPTION
The chart assumes there will only ever be one instance installed in a namespace. I'm switching some sites over to use this chart and we have a namespace with multiple instances installed in the same namespace. This PR enables the more traditional naming of resources logic in the chart, but defaults to the static names by default for backwards comparability reasons.